### PR TITLE
Fix: React useEffect causes GPU device to be destroyed

### DIFF
--- a/src/components/webgpu-canvas.tsx
+++ b/src/components/webgpu-canvas.tsx
@@ -57,8 +57,14 @@ export default function WebGPUCanvas({
     let frameRequestId: number | undefined = undefined;
     const webGPUContext = initWebGPU(device, canvasRef.current);
 
+    const controller = new AbortController();
     const init = async () => {
-      rendererRef.current = await createRenderer(webGPUContext);
+      const newRenderer = await createRenderer(webGPUContext);
+      if (controller.signal.aborted) {
+        newRenderer.dispose();
+        return;
+      }
+      rendererRef.current = newRenderer;
 
       let lastTime = Date.now();
       const doFrame = (time: number) => {
@@ -78,10 +84,11 @@ export default function WebGPUCanvas({
     // return cleanup method
     return () => {
       if (frameRequestId !== undefined) window.cancelAnimationFrame(frameRequestId);
-      if (rendererRef.current) rendererRef.current.dispose();
-      if (webGPUContext) webGPUContext.device.destroy();
-
+      rendererRef.current?.dispose();
+      webGPUContext.device?.destroy();
       rendererRef.current = undefined;
+      // abort if we haven't resolved the init promise
+      controller.abort();
     };
   }, [createRenderer, device, rendererRef]);
 

--- a/src/hooks/use-gpu-device.tsx
+++ b/src/hooks/use-gpu-device.tsx
@@ -15,16 +15,17 @@ export function GPUDeviceProvider({ children }: PropsWithChildren) {
 
   // Fetch ye olde GPU device
   useEffect(() => {
-    if (store.device) return;
-
     const controller = new AbortController();
-    let device: GPUDevice | undefined = undefined;
+
+    let device: GPUDevice | undefined;
     const init = async () => {
-      device = await getWebGPUDevice();
+      const newDevice = await getWebGPUDevice();
       // Cancel state setting if we cleanup before promise resolves
       if (controller.signal.aborted) {
+        newDevice?.destroy();
         return;
       }
+      device = newDevice;
 
       setStore({ device });
     };
@@ -32,10 +33,11 @@ export function GPUDeviceProvider({ children }: PropsWithChildren) {
     void init();
 
     return () => {
-      controller.abort();
       device?.destroy();
+      // abort if we haven't resolved the init promise
+      controller.abort();
     };
-  }, [store.device]);
+  }, []);
 
   return <GPUDeviceContext.Provider value={store}>{children}</GPUDeviceContext.Provider>;
 }


### PR DESCRIPTION
This PR makes async `useEffect` logic between `<WebGPUCanvas />` and `useGPUDevice` consistent and ensures that the active GPU device isn't automatically destroyed.