### PR TITLE
Clean up React memoization behavior

### DIFF
--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react';
 
-import { MemoizedNodeGraphCanvas } from './node-graph-canvas';
-import { MemoizedTerrainCanvas } from './terrain-canvas';
+import NodeGraphCanvas from './node-graph-canvas';
+import TerrainCanvas from './terrain-canvas';
 import TerrainSliders from './terrain-sliders';
 
 import NodeGraph from '@/components/node-graph';
@@ -41,7 +41,7 @@ export default function Editor() {
             Toolbar or something goes here
           </div>
           <div className="relative grow">
-            <MemoizedNodeGraphCanvas previewNodes={previewNodes} />
+            <NodeGraphCanvas previewNodes={previewNodes} />
             <NodeGraph />
           </div>
         </div>
@@ -49,7 +49,7 @@ export default function Editor() {
         {/* Right column */}
         <div className="relative flex flex-col overflow-clip border-l-2 border-zinc-900">
           <div className="relative aspect-4/3">
-            <MemoizedTerrainCanvas sceneGraph={sceneGraph} rendererRef={rendererRef} />
+            <TerrainCanvas sceneGraph={sceneGraph} globalParams={globalParams} />
           </div>
           <div className="relative grow">
             <div className="absolute inset-0 overflow-y-auto px-8 py-4">

--- a/src/components/editor/node-graph-canvas.tsx
+++ b/src/components/editor/node-graph-canvas.tsx
@@ -1,12 +1,15 @@
-import { memo, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
-import WebGPUCanvas from '@/components/webgpu-canvas';
+import WebGPUCanvas, { type WebGPUCanvasProps } from '@/components/webgpu-canvas';
 import { NodeGraphRenderer } from '@/lib/renderers/node-graph-renderer';
 import type { PreviewNode } from '@/lib/scene';
 
 export type NodeGraphCanvasProps = {
   previewNodes: Array<PreviewNode>;
 };
+
+const createRenderer: WebGPUCanvasProps['createRenderer'] = (webGPU) =>
+  new NodeGraphRenderer(webGPU);
 
 export default function NodeGraphCanvas({ previewNodes }: NodeGraphCanvasProps) {
   const rendererRef = useRef<NodeGraphRenderer | undefined>(undefined);
@@ -18,15 +21,9 @@ export default function NodeGraphCanvas({ previewNodes }: NodeGraphCanvasProps) 
 
   return (
     <WebGPUCanvas
-      createRenderer={(webGPU) => new NodeGraphRenderer(webGPU)}
+      createRenderer={createRenderer}
       rendererRef={rendererRef}
       divClassName="absolute inset-0"
     />
   );
 }
-
-export const MemoizedNodeGraphCanvas = memo(
-  NodeGraphCanvas,
-  (prevProps: NodeGraphCanvasProps, nextProps: NodeGraphCanvasProps) =>
-    prevProps.previewNodes === nextProps.previewNodes,
-);

--- a/src/components/editor/terrain-canvas.tsx
+++ b/src/components/editor/terrain-canvas.tsx
@@ -1,35 +1,37 @@
-import { useEffect, memo } from 'react';
+import { useEffect, useRef } from 'react';
 
-import WebGPUCanvas from '@/components/webgpu-canvas';
-import { TerrainRenderer } from '@/lib/renderers/terrain-renderer';
+import WebGPUCanvas, { type WebGPUCanvasProps } from '@/components/webgpu-canvas';
+import {
+  TerrainRenderer,
+  type TerrainRendererGlobalParameters,
+} from '@/lib/renderers/terrain-renderer';
 import type { SceneGraph } from '@/lib/scene';
 
 export type TerrainCanvasProps = {
   sceneGraph: SceneGraph;
-  rendererRef: React.RefObject<TerrainRenderer | undefined>;
+  globalParams: TerrainRendererGlobalParameters;
 };
 
-export default function TerrainCanvas({ sceneGraph, rendererRef }: TerrainCanvasProps) {
+const createRenderer: WebGPUCanvasProps['createRenderer'] = (webGPU, stage) =>
+  new TerrainRenderer(webGPU, stage);
+
+export default function TerrainCanvas({ sceneGraph, globalParams }: TerrainCanvasProps) {
+  const rendererRef = useRef<TerrainRenderer | undefined>(undefined);
+
   // Update pipelines etc when scene graph changes
   useEffect(() => {
     rendererRef.current?.setSceneGraph(sceneGraph);
   }, [sceneGraph, rendererRef]);
 
+  useEffect(() => {
+    rendererRef.current?.setMeshUniforms(globalParams.size, globalParams.resolution);
+  }, [globalParams.resolution, globalParams.size, rendererRef]);
+
   return (
     <WebGPUCanvas
-      createRenderer={(webGPU, stage) => {
-        const renderer = new TerrainRenderer(webGPU, stage);
-        rendererRef.current = renderer;
-        return renderer;
-      }}
+      createRenderer={createRenderer}
       rendererRef={rendererRef}
       divClassName="absolute inset-0 bg-zinc-900"
     />
   );
 }
-
-export const MemoizedTerrainCanvas = memo(
-  TerrainCanvas,
-  (prevProps: TerrainCanvasProps, nextProps: TerrainCanvasProps) =>
-    prevProps.sceneGraph === nextProps.sceneGraph,
-);

--- a/src/components/webgpu-canvas.tsx
+++ b/src/components/webgpu-canvas.tsx
@@ -30,7 +30,7 @@ export interface IRenderer {
   dispose: () => void;
 }
 
-interface WebGPUCanvasProps {
+export type WebGPUCanvasProps = {
   createRenderer: PossiblyAwaitable<[WebGPUContext, Stage], IRenderer>;
   /**
    * By taking rendererRef from a prop, we allow higher-level components to own and communicate
@@ -38,7 +38,7 @@ interface WebGPUCanvasProps {
    */
   rendererRef: RefObject<IRenderer | undefined>;
   divClassName?: string;
-}
+};
 
 /**
  * Reusable component to set up a `canvas` component and its context for usage with WebGPU.

--- a/src/lib/renderers/terrain-renderer.ts
+++ b/src/lib/renderers/terrain-renderer.ts
@@ -7,6 +7,11 @@ import { Mesh } from '@/lib/scene/mesh';
 import { Stage } from '@/lib/scene/stage';
 import type { WebGPUContext } from '@/lib/webgpu-context';
 
+export type TerrainRendererGlobalParameters = {
+  size: number;
+  resolution: number;
+};
+
 export class TerrainRenderer implements IRenderer {
   protected stage: Stage;
   protected camera: Camera;


### PR DESCRIPTION
## Description

This mini PR will clean up some React state behavior.

The "create renderer" callback was getting re-created every component render, so any state changes would trigger a WebGPU re-initialization. Instead, we just move the callback out of the component body, preventing re-creation.

Grr I hate React state management 👿 

Should be merged before #30 