### PR TITLE
Compute output height key

### DIFF
--- a/src/lib/graph/index.ts
+++ b/src/lib/graph/index.ts
@@ -39,8 +39,18 @@ export function generateUpdatedPipelines(
       .map((node) => getInstruction(node, orderedDependencyNodes, edges))
       .filter((instruction) => instruction !== null);
 
-    // TODO: get height key from the incoming edge of the terrain node
-    const outputs: scene.DisplacePipeline['outputs'] = { height: 'TODO' };
+    // Get height key from the incoming edge of the terrain node
+    const heightEdge = edges.find((edge) => edge.target === terrainNode.id);
+    const heightEdgeSourceNode = orderedDependencyNodes.find(
+      (node) => node.id === heightEdge?.source,
+    );
+    const outputs: scene.DisplacePipeline['outputs'] = {
+      height: nodeMapping.getHandleKey({
+        // TODO: wow these type assertions are awesome (evil as fuck)
+        sourceNode: heightEdgeSourceNode!,
+        outgoingHandleId: heightEdge!.sourceHandle!,
+      }),
+    };
 
     displacePipeline = { instructionSet, uniforms, outputs };
   }


### PR DESCRIPTION
## Description

This PR will add quick logic to find the `ReferenceKey` needed for Terrain (Output) nodes when generating instruction sets.

Resolves #63.

Node graph:

<img width="874" height="184" alt="image" src="https://github.com/user-attachments/assets/b6016bee-d571-4864-b2aa-6859ea9359a3" />

Resulting code:

```wgsl
@compute @workgroup_size(64)
fn main(@builtin(global_invocation_id) id: vec3<u32>) {
    let offset = vertexOffset(id.x);

    let terrainPos = vec3f(
        vertices[offset],
        vertices[offset + 1u],
        vertices[offset + 2u],
    );

  let hdlkey_custom_node_1763959057956_float_x_out = terrainPos.x;  
let hdlkey_custom_node_1763959057956_float_y_out = terrainPos.y;  
let hdlkey_custom_node_1763959057956_float_z_out = terrainPos.z;
  let hdlkey_custom_node_1763959377625_float_out = sin(hdlkey_custom_node_1763959057956_float_x_out);

    vertices[offset + 1u] = hdlkey_custom_node_1763959377625_float_out;
}
```
