### PR TITLE
Fix and update kb/m controls

### DIFF
--- a/src/components/editor/node-graph/index.tsx
+++ b/src/components/editor/node-graph/index.tsx
@@ -99,7 +99,10 @@ export default function NodeGraph({
         >
           <Background />
           <Controls />
-          <KeyboardShortcuts reactFlowWrapperRef={reactFlowWrapper} />
+          <KeyboardShortcuts
+            reactFlowWrapperRef={reactFlowWrapper}
+            onOpenContextMenu={onPaneContextMenu}
+          />
           <ContextMenu
             state={menuState}
             closeMenu={closeMenu}

--- a/src/components/editor/node-graph/keyboard-shortcuts.tsx
+++ b/src/components/editor/node-graph/keyboard-shortcuts.tsx
@@ -6,9 +6,13 @@ import { useMousePos } from '@/hooks/use-mouse-pos';
 
 export type KeyboardShortcutsProps = {
   reactFlowWrapperRef: RefObject<HTMLElement>;
+  onOpenContextMenu: () => void;
 };
 
-export default function KeyboardShortcuts({ reactFlowWrapperRef }: KeyboardShortcutsProps) {
+export default function KeyboardShortcuts({
+  reactFlowWrapperRef,
+  onOpenContextMenu,
+}: KeyboardShortcutsProps) {
   const { getMousePos } = useMousePos();
   const { createNode } = useGraphGlobals();
   const { screenToFlowPosition } = useReactFlow();
@@ -43,6 +47,8 @@ export default function KeyboardShortcuts({ reactFlowWrapperRef }: KeyboardShort
         createNode('separate', position);
       } else if (evt.key === 'c') {
         createNode('combine', position);
+      } else if (evt.key === 'A') {
+        onOpenContextMenu();
       }
     };
     document.addEventListener('keydown', onKeyDown);
@@ -50,7 +56,7 @@ export default function KeyboardShortcuts({ reactFlowWrapperRef }: KeyboardShort
     return () => {
       document.removeEventListener('keydown', onKeyDown);
     };
-  }, [createNode, getMousePos, reactFlowWrapperRef, screenToFlowPosition]);
+  }, [createNode, getMousePos, onOpenContextMenu, reactFlowWrapperRef, screenToFlowPosition]);
 
   return null;
 }

--- a/src/hooks/use-context-menu.ts
+++ b/src/hooks/use-context-menu.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import type { ContextMenuState } from '@/components/editor/node-graph/context-menu';
+import { useMousePos } from '@/hooks/use-mouse-pos';
 
 export type UseContextMenuOptions = {
   reactFlowWrapper: React.RefObject<HTMLElement>;
@@ -13,23 +14,26 @@ export type UseContextMenuOptions = {
  */
 export function useContextMenu({ reactFlowWrapper }: UseContextMenuOptions) {
   const [menuState, setMenuState] = useState<ContextMenuState>({ show: false });
+  const { getMousePos } = useMousePos();
 
   // logic for menu event
   const onPaneContextMenu = useCallback(
-    (event: React.MouseEvent) => {
-      event.preventDefault();
+    (event?: React.MouseEvent) => {
+      event?.preventDefault();
+
+      const mousePos = getMousePos();
 
       if (!reactFlowWrapper.current) return;
       const pane = reactFlowWrapper.current.getBoundingClientRect();
-      if (event.clientY > pane.height || event.clientX > pane.width) return;
+      if (mousePos.y > pane.height || mousePos.x > pane.width) return;
 
       setMenuState({
         show: true,
-        left: event.clientX - pane.left,
-        top: event.clientY - pane.top,
+        left: mousePos.x - pane.left,
+        top: mousePos.y - pane.top,
       });
     },
-    [reactFlowWrapper],
+    [getMousePos, reactFlowWrapper],
   );
 
   const closeMenu = useCallback(() => {


### PR DESCRIPTION
This PR will revert some previous mouse control changes, as well as fix some issues surrounding keyboard shortcuts activating even when not hovering over the nodegraph. It will also add a new shortcut (`Shift` + `A`) for the context menu.