### PR TITLE
Use non-filtering sampler for shadowmap

### DIFF
--- a/src/lib/renderers/terrain-renderer.ts
+++ b/src/lib/renderers/terrain-renderer.ts
@@ -123,7 +123,7 @@ export class TerrainRenderer implements IRenderer {
           // shadowmap sampler
           binding: 3,
           visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
-          sampler: { type: 'filtering' },
+          sampler: { type: 'non-filtering' },
         },
       ],
     });
@@ -153,8 +153,8 @@ export class TerrainRenderer implements IRenderer {
           resource: this.device.createSampler({
             addressModeU: 'clamp-to-edge',
             addressModeV: 'clamp-to-edge',
-            magFilter: 'linear',
-            minFilter: 'linear',
+            magFilter: 'nearest',
+            minFilter: 'nearest',
           }),
         },
       ],


### PR DESCRIPTION
Previously, Chrome shat itself when trying to use a sampler with filtering when the texture type was depth. This PR will mitigate that by removing all filtering from the sampler (in layout and creation).

A follow-up PR will attempt to smooth out shadows using a comparison sampler instead.